### PR TITLE
Add support for shared arrays

### DIFF
--- a/npctypes/shared.py
+++ b/npctypes/shared.py
@@ -35,6 +35,13 @@ def ndarray(shape, dtype, order=None):
         Returns:
             ctypes.Array:               Custom Array (NDArray) instance
                                         allocated on the shared process heap.
+
+        Examples:
+            >>> ndarray((2,3), float)               # doctest: +ELLIPSIS
+            <npctypes.shared.NDArray_<f8_2d_2x3_C object at 0x...>
+
+            >>> ndarray((2,3), float, order='F')    # doctest: +ELLIPSIS
+            <npctypes.shared.NDArray_<f8_2d_2x3_F object at 0x...>
     """
 
     global _ndarray_cache
@@ -102,6 +109,23 @@ def as_ndarray(a, writeable=True):
         Returns:
             ctypes.Array:               Custom Array instance allocated on the
                                         shared process heap.
+
+        Examples:
+            >>> a = ndarray((2,3), float)
+            >>> with as_ndarray(a) as nd_a:
+            ...     nd_a[...] = 0
+            ...     print(nd_a)
+            [[ 0.  0.  0.]
+             [ 0.  0.  0.]]
+
+            >>> a = ndarray((2,3), float)
+            >>> with as_ndarray(a) as nd_a:
+            ...     for i in range(nd_a.size):
+            ...         nd_a.flat[i] = i
+            ...
+            ...     print(nd_a)
+            [[ 0.  1.  2.]
+             [ 3.  4.  5.]]
     """
 
     # Construct the NumPy array object.

--- a/npctypes/shared.py
+++ b/npctypes/shared.py
@@ -1,0 +1,4 @@
+__author__ = "John Kirkham <kirkhamj@janelia.hhmi.org>"
+__date__ = "$Oct 04, 2016 16:17$"
+
+

--- a/npctypes/shared.py
+++ b/npctypes/shared.py
@@ -2,3 +2,111 @@ __author__ = "John Kirkham <kirkhamj@janelia.hhmi.org>"
 __date__ = "$Oct 04, 2016 16:17$"
 
 
+import contextlib
+import multiprocessing.sharedctypes
+
+import numpy
+
+from npctypes import types
+
+
+# Used to initiate the array from the shared process heap.
+_new_value = multiprocessing.sharedctypes._new_value
+
+_ndarray_cache = {}
+def ndarray(shape, dtype, order=None):
+    """
+        Factory to generate N-D Arrays shared across process boundaries.
+
+        This creates a custom dynamic type (if one doesn't already exist) that
+        is a ``ctypes.Array`` instance. If one does already exist, we reuse it
+        so that things like type comparisons work. In addition to the typical
+        properties that ``ctypes.Array``s have, this tracks its number of
+        dimensions, shape, and order ('C' or 'F' for C and Fortran
+        respectively). Having this information allows us to easily construct a
+        NumPy ndarray in other processes.
+
+        Args:
+            shape(tuple of ints):       Shape of the array to allocate.
+            dtype(type):                Type of the array to allocate.
+            order(char or None):        Order of the array ('C', 'F', or None).
+                                        Defaults to None.
+
+        Returns:
+            ctypes.Array:               Custom Array (NDArray) instance
+                                        allocated on the shared process heap.
+    """
+
+    global _ndarray_cache
+
+    # Ensure all args are in working order.
+    assert isinstance(shape, tuple), \
+        "`shape` must be a `tuple`"
+
+    dtype = numpy.dtype(dtype)
+
+    if order is None:
+        order = 'C'
+    else:
+        assert order in ['C', 'F'], \
+            "`order` must be `'C'` or `'F'`."
+
+    ndim = len(shape)
+
+    # Get the C type values
+    ctype = types.ctype(dtype)
+    size = int(numpy.prod(shape))
+
+    try:
+        NDArray = _ndarray_cache[(ctype, size, ndim, shape, order)]
+    except KeyError:
+        # Create an NDArray that inherits from the C type array.
+        array_type = size * ctype
+        NDArray = type(
+            "_".join([
+                "NDArray",
+                dtype.str,
+                "%id" % ndim,
+                "x".join([str(_) for _ in shape]),
+                order
+            ]),
+            (array_type,),
+            dict(
+                _type_ = ctype,
+                _length_ = size,
+                _ndim_ = ndim,
+                _shape_ = shape,
+                _order_ = order,
+            )
+        )
+
+        _ndarray_cache[(ctype, size, ndim, shape, order)] = NDArray
+
+    # Create a new instance of the NDArray type on shared storage.
+    a = _new_value(NDArray)
+
+    return a
+
+
+@contextlib.contextmanager
+def as_ndarray(a, writeable=True):
+    """
+        Context manager to provide NumPy ndarray views of NDArray instances.
+
+        Args:
+            shape(tuple of ints):       Shape of the array to allocate.
+            dtype(type):                Type of the array to allocate.
+            order(char or None):        Order of the array ('C', 'F', or None).
+                                        Defaults to None.
+
+        Returns:
+            ctypes.Array:               Custom Array instance allocated on the
+                                        shared process heap.
+    """
+
+    # Construct the NumPy array object.
+    nd_a = numpy.frombuffer(a, dtype=a._type_)
+    nd_a = nd_a.reshape(a._shape_, order=a._order_)
+    nd_a.flags["WRITEABLE"] = writeable
+
+    yield nd_a

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -1,0 +1,4 @@
+__author__ = "John Kirkham <kirkhamj@janelia.hhmi.org>"
+__date__ = "$Oct 05, 2016 9:46$"
+
+

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -1,4 +1,21 @@
+#!/usr/bin/env python
+
 __author__ = "John Kirkham <kirkhamj@janelia.hhmi.org>"
 __date__ = "$Oct 05, 2016 9:46$"
 
 
+import doctest
+import sys
+import unittest
+
+from npctypes import shared
+
+
+# Load doctests from `shared`.
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocTestSuite(shared))
+    return tests
+
+
+if __name__ == '__main__':
+    sys.exit(unittest.main())

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -4,7 +4,9 @@ __author__ = "John Kirkham <kirkhamj@janelia.hhmi.org>"
 __date__ = "$Oct 05, 2016 9:46$"
 
 
+import ctypes
 import doctest
+import multiprocessing
 import sys
 import unittest
 
@@ -15,6 +17,42 @@ from npctypes import shared
 def load_tests(loader, tests, ignore):
     tests.addTests(doctest.DocTestSuite(shared))
     return tests
+
+
+class TestWrappers(unittest.TestCase):
+    def setUp(self):
+        self.a = shared.ndarray((2, 3), float)
+
+    def test_instance_Array(self):
+        self.assertIsInstance(self.a, ctypes.Array)
+
+    def test_Process(self):
+        def test(a):
+            with shared.as_ndarray(a) as nd_a:
+                for i in range(nd_a.size):
+                    nd_a.flat[i] = i
+
+        p = multiprocessing.Process(
+            target=test,
+            args=(self.a,)
+        )
+        p.run()
+
+        self.assertListEqual(list(self.a), list(range(len(self.a))))
+
+    def test_not_writeable(self):
+        with self.assertRaises(ValueError):
+            with shared.as_ndarray(self.a, writeable=False) as nd_a:
+                nd_a[...] = 0
+
+    def test_not_writeable_2(self):
+        with self.assertRaisesRegexp(ValueError,
+                                     "assignment destination is read-only"):
+            with shared.as_ndarray(self.a, writeable=False) as nd_a:
+                nd_a[...] = 0
+
+    def tearDown(self):
+        del self.a
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds a shared array type for use with `multiprocessing` that is based off of `ctype.Array`s, but for use as a shared memory array like `multiprocessing.RawArray`. However, it has additional metadata to aid in use with NumPy. It also includes a context manager function so as to convert the 1-D array into an N-D NumPy array. From there any computation can be done in parallel.
