### PR TITLE
Require NumPy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 requirements = [
-    # TODO: put package requirements here
+    "numpy",
 ]
 
 test_requirements = [


### PR DESCRIPTION
Add `numpy` to `setup.py`'s install time requirements.
