### PR TITLE
Use NumPy 1.13 legacy print mode in doctests

### DIFF
--- a/environment_ci.yml
+++ b/environment_ci.yml
@@ -8,4 +8,4 @@ dependencies:
   - wheel==0.29.0
   - coverage==3.7.1
   - python-coveralls==2.5.0
-  - numpy==1.12.0
+  - numpy==1.15.4

--- a/npctypes/shared.py
+++ b/npctypes/shared.py
@@ -111,6 +111,7 @@ def as_ndarray(a, writeable=True):
                                         shared process heap.
 
         Examples:
+
             >>> a = ndarray((2,3), float)
             >>> with as_ndarray(a) as nd_a:
             ...     nd_a[...] = 0

--- a/npctypes/shared.py
+++ b/npctypes/shared.py
@@ -112,6 +112,8 @@ def as_ndarray(a, writeable=True):
 
         Examples:
 
+            >>> numpy.set_printoptions(legacy="1.13")
+
             >>> a = ndarray((2,3), float)
             >>> with as_ndarray(a) as nd_a:
             ...     nd_a[...] = 0

--- a/npctypes/types.py
+++ b/npctypes/types.py
@@ -104,6 +104,7 @@ def get_ndpointer_type(a):
               OWNDATA : True
               WRITEABLE : False
               ALIGNED : True
+              WRITEBACKIFCOPY : False
               UPDATEIFCOPY : False
     """
 

--- a/npctypes/types.py
+++ b/npctypes/types.py
@@ -83,6 +83,7 @@ def get_ndpointer_type(a):
             (PyCSimpleType):   the pointer type associated with this array.
 
         Examples:
+
             >>> a = numpy.zeros((3, 4), dtype=float)
             >>> a_ptr = get_ndpointer_type(a)
 


### PR DESCRIPTION
Fixes https://github.com/jakirkham/npctypes/issues/14

To keep the doctests consistent over time, use the NumPy 1.13 legacy print mode. Should keep the maintenance effort of doctests to a minimum.